### PR TITLE
Allow number of methods warning level configuration

### DIFF
--- a/lib/src/analysis_options.dart
+++ b/lib/src/analysis_options.dart
@@ -41,6 +41,7 @@ class AnalysisOptions {
           linesOfCodeWarningLevel: configMap['lines-of-code'] as int,
           numberOfArgumentsWarningLevel:
               configMap['number-of-arguments'] as int,
+          numberOfMethodsWarningLevel: configMap['number-of-methods'] as int,
         );
       }
 

--- a/test/analysis_options_test.dart
+++ b/test/analysis_options_test.dart
@@ -68,6 +68,7 @@ dart_code_metrics:
   metrics:
     cyclomatic-complexity: 20
     number-of-arguments: 4
+    number-of-methods: 8
   rules:
     - no-boolean-literal-compare
 
@@ -88,6 +89,7 @@ analyzer:
 dart_code_metrics:
   metrics:
     cyclomatic-complexity: 20
+    lines-of-code: 42
   metrics-exclude:
     - test/**
   rules:
@@ -159,6 +161,7 @@ void main() {
         expect(
             options.metricsConfig.cyclomaticComplexityWarningLevel, equals(20));
         expect(options.metricsConfig.numberOfArgumentsWarningLevel, equals(4));
+        expect(options.metricsConfig.numberOfMethodsWarningLevel, equals(8));
         expect(options.metricsExcludePatterns, isEmpty);
         expect(options.rules,
             equals({'no-boolean-literal-compare': <String, Object>{}}));
@@ -170,6 +173,7 @@ void main() {
 
         expect(
             options.metricsConfig.cyclomaticComplexityWarningLevel, equals(20));
+        expect(options.metricsConfig.linesOfCodeWarningLevel, equals(42));
         expect(options.metricsExcludePatterns.single, equals('test/**'));
         expect(options.rules,
             equals({'no-boolean-literal-compare': <String, Object>{}}));


### PR DESCRIPTION
AnalysisOptions missed "number of methods" option reading from configuration.