### PR TITLE
Fix member-ordering rule multiple classes processing

### DIFF
--- a/lib/src/rules/member_ordering.dart
+++ b/lib/src/rules/member_ordering.dart
@@ -37,7 +37,7 @@ class MemberOrderingRule extends BaseRule {
 
     final membersInfo = [
       for (final entry in unit.childEntities)
-        if (entry is ClassMember) ...entry.accept(_visitor),
+        if (entry is ClassDeclaration) ...entry.accept(_visitor),
     ];
 
     return [

--- a/lib/src/rules/member_ordering.dart
+++ b/lib/src/rules/member_ordering.dart
@@ -36,7 +36,7 @@ class MemberOrderingRule extends BaseRule {
     final _visitor = _Visitor(_groupsOrder);
 
     final membersInfo = [
-      for (final entry in  unit.childEntities)
+      for (final entry in unit.childEntities)
         if (entry is ClassMember) ...entry.accept(_visitor),
     ];
 

--- a/lib/src/rules/member_ordering.dart
+++ b/lib/src/rules/member_ordering.dart
@@ -35,10 +35,13 @@ class MemberOrderingRule extends BaseRule {
   ) {
     final _visitor = _Visitor(_groupsOrder);
 
-    unit.visitChildren(_visitor);
+    final membersInfo = [
+      for (final entry in  unit.childEntities)
+        if (entry is ClassMember) ...entry.accept(_visitor),
+    ];
 
     return [
-      ..._visitor.membersInfo.where((info) => info.memberOrder.isWrong).map(
+      ...membersInfo.where((info) => info.memberOrder.isWrong).map(
             (info) => createIssue(
                 this,
                 '${info.memberOrder.memberGroup.name} $_warningMessage ${info.memberOrder.previousMemberGroup.name}',
@@ -50,7 +53,7 @@ class MemberOrderingRule extends BaseRule {
                 info.classMember),
           ),
       if (_alphabetize)
-        ..._visitor.membersInfo
+        ...membersInfo
             .where((info) => info.memberOrder.isAlphabeticallyWrong)
             .map(
               (info) => createIssue(
@@ -78,17 +81,17 @@ class MemberOrderingRule extends BaseRule {
   }
 }
 
-class _Visitor extends RecursiveAstVisitor<void> {
+class _Visitor extends RecursiveAstVisitor<List<_MemberInfo>> {
   final List<_MembersGroup> _groupsOrder;
   final _membersInfo = <_MemberInfo>[];
-
-  Iterable<_MemberInfo> get membersInfo => _membersInfo;
 
   _Visitor(this._groupsOrder);
 
   @override
-  void visitClassDeclaration(ClassDeclaration node) {
+  List<_MemberInfo> visitClassDeclaration(ClassDeclaration node) {
     super.visitClassDeclaration(node);
+
+    _membersInfo.clear();
 
     for (final member in node.members) {
       if (member is FieldDeclaration) {
@@ -99,6 +102,8 @@ class _Visitor extends RecursiveAstVisitor<void> {
         _visitMethodDeclaration(member);
       }
     }
+
+    return _membersInfo;
   }
 
   void _visitFieldDeclaration(FieldDeclaration fieldDeclaration) {

--- a/test/rules/member_ordering_test.dart
+++ b/test/rules/member_ordering_test.dart
@@ -176,7 +176,7 @@ void main() {
     );
   });
 
-  test('MemberOrdering with default config and multiple classes in file reports no issues', () {
+  test('MemberOrdering with multiple classes in file reports no issues', () {
     final sourceUrl = Uri.parse('/example.dart');
     final parseResult = parseString(
         content: _multipleClassesContent,

--- a/test/rules/member_ordering_test.dart
+++ b/test/rules/member_ordering_test.dart
@@ -38,6 +38,30 @@ class Test {
 
 ''';
 
+const _multipleClassesContent = '''
+
+class Test {
+  final _data = 1;
+
+  int get data => _data;
+
+  void doWork() {
+
+  }
+}
+
+class AnotherTest {
+  final _anotherData = 1;
+
+  int get anotherData => _anotherData;
+
+  void anotherDoWork() {
+
+  }
+}
+
+''';
+
 const _angularContent = '''
 
 class Test {
@@ -150,6 +174,28 @@ void main() {
         'public_getters should be before private_methods',
       ]),
     );
+  });
+
+  test('MemberOrdering with default config and multiple classes in file reports no issues', () {
+    final sourceUrl = Uri.parse('/example.dart');
+    final parseResult = parseString(
+        content: _multipleClassesContent,
+        featureSet: FeatureSet.fromEnableFlags([]),
+        throwIfDiagnostics: false);
+
+    final issues = MemberOrderingRule()
+        .check(parseResult.unit, sourceUrl, parseResult.content);
+
+    expect(
+      issues.every((issue) => issue.ruleId == 'member-ordering'),
+      isTrue,
+    );
+    expect(
+      issues.every((issue) => issue.severity == CodeIssueSeverity.style),
+      isTrue,
+    );
+
+    expect(issues.isEmpty, isTrue);
   });
 
   test('MemberOrdering with custom config reports about found issues', () {


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix
[ ] New rule
[ ] Changes an existing rule
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If this pull request is addressing an issue, please paste a link to the issue here.
-->

<!--
    Please ensure your pull request is ready:

    - Include tests for this change
    - Update documentation for this change
-->

### What changes did you make? (Give an overview)
Initial implementation was considering that there will be a new instance of visitor per parsed class, but it turned out that it creates a single instance for parsed file. This fix allows to get rid of false positives in files with multiple classes.

### Is there anything you'd like reviewers to focus on?
I have change the way the rule processes content. Its now an `accept` method instead of `visitChildren`.