### PR TITLE
Fix false positive trigger for prefer-conditional-expression rule

### DIFF
--- a/lib/src/rules/prefer_conditional_expressions.dart
+++ b/lib/src/rules/prefer_conditional_expressions.dart
@@ -83,7 +83,9 @@ class _Visitor extends RecursiveAstVisitor<void> {
   void visitIfStatement(IfStatement node) {
     super.visitIfStatement(node);
 
-    if (node.elseStatement != null && node.elseStatement is! IfStatement) {
+    if (node.parent is! IfStatement &&
+        node.elseStatement != null &&
+        node.elseStatement is! IfStatement) {
       _checkBothAssignment(node);
       _checkBothReturn(node);
     }

--- a/test/rules/prefer_conditional_expressions_test.dart
+++ b/test/rules/prefer_conditional_expressions_test.dart
@@ -118,6 +118,14 @@ int anotherTestFunction() {
 
     return 2;
   } else return 6;
+
+  if (a == 4) {
+    a = 4;
+  } else if (a == 5) {
+    a = 5;
+  } else {
+    a = 6;
+  }
 }
 
 ''';


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix
[ ] New rule
[ ] Changes an existing rule
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If this pull request is addressing an issue, please paste a link to the issue here.
-->

<!--
    Please ensure your pull request is ready:

    - Include tests for this change
    - Update documentation for this change
-->

### What changes did you make? (Give an overview)
I have added a check for if statement parent not to be an if statement.
