### PR TITLE
Add provided args check for intl message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# Unreleased
+
+- Improve static code diagnostic for prefer-intl-name
+
 # 1.8.1
 
 - Fix static code diagnostics member-ordering and prefer-condifional-expression

--- a/doc/rules/prefer_intl_name.md
+++ b/doc/rules/prefer_intl_name.md
@@ -1,13 +1,18 @@
 # Prefer Intl name
 
 ## Rule id
+
 prefer-intl-name
 
 ## Description
+
 Prefer used pattern `${ClassName}_${ClassMemberName}` for `name` argument in `Intl.message()`, `Intl.plural()`, `Intl.gender()`, `Intl.select()` methods.
+Also warns when args not provided to message string interpolation.
 
 ### Example
+
 Bad:
+
 ```dart
 import 'package:intl/intl.dart';
 
@@ -20,29 +25,29 @@ class SomeButtonI18n {
   final String title2 = Intl.message(
     'Two Title',
     name: 'titleTwo'
-  );  
+  );
 
   String get title3 => Intl.message(
     'Three Title',
     name: 'SomeButtonI18n_titleThree'
-  );  
-  
+  );
+
   static String get title4 => Intl.message(
     'Four Title',
     name: 'SomeButtonI18n_titleFour'
-  ); 
-  
+  );
+
   String title5() => Intl.message(
     'Five Title',
     name: 'SomeButtonI18n_titleFive'
-  );  
-  
+  );
+
   static String title6() {
     return Intl.message(
       'Six Title',
       name: 'SomeButtonI18n_titleSix'
      );
-  } 
+  }
 }
 
 String title7() {
@@ -59,6 +64,7 @@ String title8() => Intl.message(
 ```
 
 Good:
+
 ```dart
 import 'package:intl/intl.dart';
 
@@ -73,29 +79,29 @@ class SomeButtonCorrectI18n {
   final String title2 = Intl.message(
     'Two Title',
     name: 'SomeButtonCorrectI18n_title2'
-  );  
+  );
 
   String get title3 => Intl.message(
     'Three Title',
     name: 'SomeButtonCorrectI18n_title3'
-  );  
-  
+  );
+
   static String get title4 => Intl.message(
     'Four Title',
     name: 'SomeButtonCorrectI18n_title4'
-  );   
+  );
 
   String get title5 => Intl.message(
     'Three Title',
     name: 'SomeButtonCorrectI18n_title5'
-  );  
-  
+  );
+
   static String get title6 => Intl.message(
     'Four Title',
     name: 'SomeButtonCorrectI18n_title6'
-  ); 
+  );
 }
-  
+
 String title77() {
   return Intl.message(
     'Seven seven Title',

--- a/test/rules/prefer_intl_args_test.dart
+++ b/test/rules/prefer_intl_args_test.dart
@@ -1,9 +1,12 @@
 @TestOn('vm')
+
 import 'package:analyzer/dart/analysis/features.dart';
 import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:dart_code_metrics/src/models/code_issue_severity.dart';
 import 'package:dart_code_metrics/src/rules/prefer_intl_name.dart';
 import 'package:test/test.dart';
+
+// ignore_for_file: use_raw_strings
 
 const _incorrectContent = '''
 import 'package:intl/intl.dart';
@@ -42,7 +45,7 @@ class ClassI18n {
 }
 ''';
 
-final _correctContent = '''
+const _correctContent = '''
 import 'package:intl/intl.dart';
 
 final Iterable<String> titles = ['first', 'second'];

--- a/test/rules/prefer_intl_args_test.dart
+++ b/test/rules/prefer_intl_args_test.dart
@@ -1,0 +1,154 @@
+@TestOn('vm')
+import 'package:analyzer/dart/analysis/features.dart';
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:dart_code_metrics/src/models/code_issue_severity.dart';
+import 'package:dart_code_metrics/src/rules/prefer_intl_name.dart';
+import 'package:test/test.dart';
+
+const _incorrectContent = '''
+import 'package:intl/intl.dart';
+
+final Iterable<String> titles = ['first', 'second'];
+final title = 'first';
+
+class ClassI18n {
+  static final String staticFinalFieldInClassTitle = Intl.message(
+    'static final field in class \$title,
+    name: 'ClassI18n_staticFinalFieldInClassTitle',
+    args: <Object>[],
+  );
+
+  static String get staticPropertyWithExpressionInClassTitle => Intl.message(
+        'static property with expression in class \$title',
+        name: 'ClassI18n_staticPropertyWithExpressionInClassTitle',
+      );
+
+  static String staticMethodExpressionInClassTitle(String title) => Intl.message(
+        'static method with expression in class \$title',
+        name: 'ClassI18n_staticMethodExpressionInClassTitle',
+      );
+
+  final String finalFieldInClassTitle = Intl.message(
+    'final field in class \${titles.map((title) => title)} \$title',
+    name: 'ClassI18n_finalFieldInClassTitle',
+    args: <Object>[titles],
+  );
+
+  String get propertyWithExpressionInClassTitle => Intl.message(
+        'property with expression in class \${titles.map((title) => title)} \$title',
+        name: 'ClassI18n_propertyWithExpressionInClassTitle',
+        args: <Object>[title],
+      );
+}
+''';
+
+final _correctContent = '''
+import 'package:intl/intl.dart';
+
+final Iterable<String> titles = ['first', 'second'];
+final title = 'first';
+
+final String finalFieldTitle = Intl.message(
+  'final field \${titles.map((title) => title)} \$title',
+  name: 'finalFieldTitle',
+  args: <Object>[titles, title],
+);
+
+String get propertyWithExpressionTitle => Intl.message(
+  'property with expression \${titles.map((title) => title)}',
+  name: 'propertyWithExpressionTitle',
+  args: <Object>[titles],
+);
+
+String methodExpressionTitle(String title) => Intl.message(
+  'method with expression \$title',
+  name: 'methodExpressionTitle',
+  args: <Object>[title],
+);
+
+String methodExpressionTitleEmptyArgument() => Intl.message(
+  'method with expression \$title',
+  name: 'methodExpressionTitleEmptyArgument',
+  args: <Object>[title],
+);
+
+String methodExpressionTitleEmptyArgs() => Intl.message(
+  'method with expression',
+  name: 'methodExpressionTitleEmptyArgs',
+  args: <Object>[],
+);
+''';
+
+void main() {
+  group('PreferIntlNameRule reports', () {
+    final sourceUrl = Uri.parse('/example.dart');
+
+    test('found issues', () {
+      final parseResult = parseString(
+          content: _incorrectContent,
+          featureSet: FeatureSet.fromEnableFlags([]),
+          throwIfDiagnostics: false);
+
+      final issues = PreferIntlNameRule()
+          .check(parseResult.unit, sourceUrl, parseResult.content);
+
+      expect(
+        issues.every((issue) => issue.ruleId == 'prefer-intl-name'),
+        isTrue,
+      );
+      expect(
+        issues.every((issue) => issue.severity == CodeIssueSeverity.warning),
+        isTrue,
+      );
+
+      expect(
+        issues.map((issue) => issue.sourceSpan.start.offset),
+        equals([299, 386, 605, 920, 1169]),
+      );
+      expect(
+        issues.map((issue) => issue.sourceSpan.start.line),
+        equals([10, 13, 18, 26, 32]),
+      );
+      expect(
+        issues.map((issue) => issue.sourceSpan.start.column),
+        equals([11, 70, 74, 11, 15]),
+      );
+      expect(
+        issues.map((issue) => issue.sourceSpan.end.offset),
+        equals([309, 393, 612, 936, 1184]),
+      );
+      expect(
+        issues.map((issue) => issue.sourceSpan.text),
+        equals([
+          '<Object>[]',
+          'message',
+          'message',
+          '<Object>[titles]',
+          '<Object>[title]',
+        ]),
+      );
+      expect(
+        issues.map((issue) => issue.message),
+        equals([
+          'title is not provided to args',
+          'No arguments provided for interpolation',
+          'No arguments provided for interpolation',
+          'title is not provided to args',
+          'titles is not provided to args',
+        ]),
+      );
+    });
+
+    test('no found issues', () {
+      final parseResult = parseString(
+          content: _correctContent,
+          featureSet: FeatureSet.fromEnableFlags([]),
+          throwIfDiagnostics: false);
+
+      final issues = PreferIntlNameRule()
+          .check(parseResult.unit, sourceUrl, parseResult.content);
+
+      expect(issues, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix
[ ] New rule
[x] Changes an existing rule
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If this pull request is addressing an issue, please paste a link to the issue here.
-->

<!--
    Please ensure your pull request is ready:

    - Include tests for this change
    - Update documentation for this change
-->

### What changes did you make? (Give an overview)
The rule now checks for message arguments and warns when they are not provided to `args`.
Closes #70 
