### PR TITLE
Explain how to use the tool with Flutter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.1
+
+- Explained usage with Flutter in README.
+
 ## 2.1.0
 
 - Add static code diagnostics no-equal-arguments, potential-null-dereference

--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ pub global activate dart_code_metrics
 metrics lib
 ```
 
-If you want to run the tool directly (e.g. because you are using Flutter), you can use:
+#### Flutter usage
 
 ```bash
 flutter pub global run dart_code_metrics:metrics lib
 ```
 
-Full usage:
+#### Full usage:
 
 ```text
 Usage: metrics [options...] <directories>

--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ pub global activate dart_code_metrics
 metrics lib
 ```
 
+If you want to run the tool directly (e.g. because you are using Flutter), you can use:
+
+```bash
+flutter pub global run dart_code_metrics:metrics lib
+```
+
 Full usage:
 
 ```text

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_code_metrics
 description: Software analytics tool that helps developers analyse and improve software quality.
-version: 2.1.0
+version: 2.1.1
 homepage: https://github.com/wrike/dart-code-metrics
 
 environment:


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

- [x] Documentation update

<!--
    If this pull request is addressing an issue, please paste a link to the issue here.
-->

<!--
    Please ensure your pull request is ready:

    - Include tests for this change
    - Update documentation for this change
-->

### What changes did you make? (Give an overview)

I explained how to use the tool with Flutter. This was not obvious before for two reasons:

* When using Flutter, the Pub executables directory is not added to path by default.
* The `metrics` executable uses `pub`, which is not available when using Flutter (only `flutter pub` is available).