### PR TITLE
Fixes the output parsed by the Code Climate CLI

### DIFF
--- a/bin/metrics.dart
+++ b/bin/metrics.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_code_metrics/metrics_analyzer.dart';
@@ -120,7 +121,15 @@ Future<void> _runAnalysis(
       throw ArgumentError.value(reporterType, 'reporter');
   }
 
-  reporter.report(runner.results()).forEach(print);
+  if (reporterType == 'codeclimate') {
+    final dynamic testresult =
+        jsonDecode(reporter.report(runner.results()).first);
+    for (final test in testresult) {
+      print('${jsonEncode(test)}\x00');
+    }
+  } else {
+    reporter.report(runner.results()).forEach(print);
+  }
 
   if (setExitOnViolationLevel != null &&
       UtilitySelector.maxViolationLevel(runner.results(), config) >=


### PR DESCRIPTION
### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix
[ ] New rule
[ ] Changes an existing rule
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Closes #175. I'm not sure how to include tests for this. However, I can verify that this quick-and-dirty fix resolves my issue at zgosalvez/codeclimate-dart/pull/1 when I tried it on my private Flutter project. My issue contains comments describing the problem with the `codeclimate` reporter in that it is not generating the correct output specified at [codeclimate/platform/blob/master/spec/analyzers/SPEC.md#output](https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#output).

### What changes did you make? (Give an overview)
Fixed the `codeclimate` reporter, which couldn't be read by the [Code Climate CLI](https://github.com/codeclimate/codeclimate) as shown in wrike/codeclimate-dart/pull/2.

### Is there anything you'd like reviewers to focus on?
The [wrike/codeclimate-dart](https://github.com/wrike/codeclimate-dart/) repository is very silent. I'm attempting to submit my fork to the [list of engines](https://docs.codeclimate.com/docs/list-of-engines) on Code Climate, so any help to get the dart engine on the list and working is appreciated.