### PR TITLE
(#183) Rules are not canonicalized during matching

### DIFF
--- a/lib/src/ignore_info.dart
+++ b/lib/src/ignore_info.dart
@@ -12,15 +12,18 @@ class IgnoreInfo {
   bool get hasIgnoreInfo =>
       _ignoreMap.isNotEmpty || _ignoreForFileSet.isNotEmpty;
 
-  bool ignoreRule(String ruleId) => _ignoreForFileSet.contains(ruleId.trim().toLowerCase());
+  bool ignoreRule(String ruleId) =>
+      _ignoreForFileSet.contains(canonicalize(ruleId));
 
   bool ignoredAt(String ruleId, int line) =>
-      ignoreRule(ruleId.trim().toLowerCase()) || (_ignoreMap[line]?.contains(ruleId.trim().toLowerCase()) ?? false);
+      ignoreRule(canonicalize(ruleId)) ||
+      (_ignoreMap[line]?.contains(canonicalize(ruleId)) ?? false);
+
+  String canonicalize(String ruleId) => ruleId.trim().toLowerCase();
 
   IgnoreInfo.calculateIgnores(String content, LineInfo info) {
     for (final match in _ignoreMatchers.allMatches(content)) {
-      final codes =
-          match.group(1).split(',').map((code) => code.trim().toLowerCase());
+      final codes = match.group(1).split(',').map(canonicalize);
       final location = info.getLocation(match.start);
       final lineNumber = location.lineNumber;
       final beforeMatch = content.substring(
@@ -37,8 +40,7 @@ class IgnoreInfo {
     }
 
     for (final match in _ignoreForFileMatcher.allMatches(content)) {
-      _ignoreForFileSet.addAll(
-          match.group(1).split(',').map((code) => code.trim().toLowerCase()));
+      _ignoreForFileSet.addAll(match.group(1).split(',').map(canonicalize));
     }
   }
 }

--- a/lib/src/ignore_info.dart
+++ b/lib/src/ignore_info.dart
@@ -13,17 +13,17 @@ class IgnoreInfo {
       _ignoreMap.isNotEmpty || _ignoreForFileSet.isNotEmpty;
 
   bool ignoreRule(String ruleId) =>
-      _ignoreForFileSet.contains(canonicalize(ruleId));
+      _ignoreForFileSet.contains(_canonicalize(ruleId));
 
   bool ignoredAt(String ruleId, int line) =>
-      ignoreRule(canonicalize(ruleId)) ||
-      (_ignoreMap[line]?.contains(canonicalize(ruleId)) ?? false);
+      ignoreRule(ruleId) ||
+      (_ignoreMap[line]?.contains(_canonicalize(ruleId)) ?? false);
 
-  String canonicalize(String ruleId) => ruleId.trim().toLowerCase();
+  String _canonicalize(String ruleId) => ruleId.trim().toLowerCase();
 
   IgnoreInfo.calculateIgnores(String content, LineInfo info) {
     for (final match in _ignoreMatchers.allMatches(content)) {
-      final codes = match.group(1).split(',').map(canonicalize);
+      final codes = match.group(1).split(',').map(_canonicalize);
       final location = info.getLocation(match.start);
       final lineNumber = location.lineNumber;
       final beforeMatch = content.substring(
@@ -40,7 +40,7 @@ class IgnoreInfo {
     }
 
     for (final match in _ignoreForFileMatcher.allMatches(content)) {
-      _ignoreForFileSet.addAll(match.group(1).split(',').map(canonicalize));
+      _ignoreForFileSet.addAll(match.group(1).split(',').map(_canonicalize));
     }
   }
 }

--- a/lib/src/ignore_info.dart
+++ b/lib/src/ignore_info.dart
@@ -12,10 +12,10 @@ class IgnoreInfo {
   bool get hasIgnoreInfo =>
       _ignoreMap.isNotEmpty || _ignoreForFileSet.isNotEmpty;
 
-  bool ignoreRule(String ruleId) => _ignoreForFileSet.contains(ruleId);
+  bool ignoreRule(String ruleId) => _ignoreForFileSet.contains(ruleId.trim().toLowerCase());
 
   bool ignoredAt(String ruleId, int line) =>
-      ignoreRule(ruleId) || (_ignoreMap[line]?.contains(ruleId) ?? false);
+      ignoreRule(ruleId.trim().toLowerCase()) || (_ignoreMap[line]?.contains(ruleId.trim().toLowerCase()) ?? false);
 
   IgnoreInfo.calculateIgnores(String content, LineInfo info) {
     for (final match in _ignoreMatchers.allMatches(content)) {

--- a/test/ignore_info_test.dart
+++ b/test/ignore_info_test.dart
@@ -28,6 +28,20 @@ void main() {
 // ignore_for_file: rule_id2, rule_id3
 ''';
 
+const _contentWithCamelCaseIgnores = '''
+// ignore_for_file: ruleId1
+
+void main() {
+  // ignore: ruleId4
+  var a = 5; // ignore: ruleId5
+
+  // ignore: ruleId6, ruleId7
+  var b = a + 5; // ignore: ruleId8, ruleId9
+}
+
+// ignore_for_file: ruleId2, ruleId3
+''';
+
 void main() {
   group('IgnoreInfo from', () {
     test('content without ignores', () {
@@ -69,6 +83,34 @@ void main() {
       expect(ignoreInfo.ignoredAt('rule_id7', 8), isTrue);
       expect(ignoreInfo.ignoredAt('rule_id8', 8), isTrue);
       expect(ignoreInfo.ignoredAt('rule_id9', 8), isTrue);
+    });
+    
+    test('content with camelcase ignores', () {
+      final parseResult = parseString(
+        content: _contentWithCamelCaseIgnores,
+        featureSet: FeatureSet.fromEnableFlags([]),
+        throwIfDiagnostics: false,
+      );
+
+      final ignoreInfo = IgnoreInfo.calculateIgnores(
+          parseResult.content, parseResult.lineInfo);
+
+      expect(ignoreInfo.hasIgnoreInfo, isTrue);
+
+      expect(ignoreInfo.ignoreRule('ruleId1'), isTrue);
+      expect(ignoreInfo.ignoreRule('ruleId2'), isTrue);
+      expect(ignoreInfo.ignoreRule('ruleId3'), isTrue);
+      expect(ignoreInfo.ignoreRule('ruleId4'), isFalse);
+
+      expect(ignoreInfo.ignoredAt('ruleId1', 5), isTrue);
+      expect(ignoreInfo.ignoredAt('ruleId2', 8), isTrue);
+      expect(ignoreInfo.ignoredAt('ruleId3', 2), isTrue);
+      expect(ignoreInfo.ignoredAt('ruleId4', 5), isTrue);
+      expect(ignoreInfo.ignoredAt('ruleId5', 5), isTrue);
+      expect(ignoreInfo.ignoredAt('ruleId6', 8), isTrue);
+      expect(ignoreInfo.ignoredAt('ruleId7', 8), isTrue);
+      expect(ignoreInfo.ignoredAt('ruleId8', 8), isTrue);
+      expect(ignoreInfo.ignoredAt('ruleId9', 8), isTrue);
     });
   });
 }

--- a/test/ignore_info_test.dart
+++ b/test/ignore_info_test.dart
@@ -84,7 +84,7 @@ void main() {
       expect(ignoreInfo.ignoredAt('rule_id8', 8), isTrue);
       expect(ignoreInfo.ignoredAt('rule_id9', 8), isTrue);
     });
-    
+
     test('content with camelcase ignores', () {
       final parseResult = parseString(
         content: _contentWithCamelCaseIgnores,


### PR DESCRIPTION
### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix
[ ] New rule
[ ] Changes an existing rule
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

### What changes did you make? (Give an overview)
Ignore rules in the analyzed code were not being canonicalized during matching, only when constructing the rule cache. This could have led to a potential mis-application of the ignore comments.

closes #183 